### PR TITLE
Upgrade to PHP 8.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - redis
     expose:
       - 9000
+      - 9003
     volumes:
       - php-src:/var/www/php_src
   redis:

--- a/services/php/build/7.3.Dockerfile
+++ b/services/php/build/7.3.Dockerfile
@@ -1,25 +1,26 @@
-FROM php:7.4-fpm
+FROM php:7.3-fpm
 
 RUN apt-get update \
     && apt-get install -y procps
 
-## Core Extensions
+## Core Extensions ##
 RUN apt-get install -y libpng-dev libxml2-dev libxslt-dev libzip-dev \
     && docker-php-ext-install gd mysqli pdo_mysql sockets xmlrpc xsl zip
 
-# PECL Extensions
+## Memcache ##
 RUN apt-get install -y libmemcached-dev memcached \
     && echo '' | pecl install -o -f memcached \
     && docker-php-ext-enable memcached
 
+## Redis ##
 RUN echo '' | pecl install -o -f redis \
     &&  rm -rf /tmp/pear \
     && docker-php-ext-enable redis
 
+## Xdebug (Optional) ##
 RUN pecl install --onlyreqdeps xdebug \
     && docker-php-ext-enable xdebug \
     && echo "xdebug.default_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \

--- a/services/php/build/7.4.Dockerfile
+++ b/services/php/build/7.4.Dockerfile
@@ -1,0 +1,27 @@
+FROM php:7.4-fpm
+
+RUN apt-get update \
+    && apt-get install -y procps
+
+## Core Extensions ##
+RUN apt-get install -y libpng-dev libxml2-dev libxslt-dev libzip-dev \
+    && docker-php-ext-install gd mysqli pdo_mysql sockets xmlrpc xsl zip
+
+## Memcache ##
+RUN apt-get install -y libmemcached-dev memcached \
+    && echo '' | pecl install -o -f memcached \
+    && docker-php-ext-enable memcached
+
+## Redis ##
+RUN echo '' | pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    && docker-php-ext-enable redis
+
+## Xdebug (Optional) ##
+RUN pecl install --onlyreqdeps xdebug \
+    && docker-php-ext-enable xdebug \
+    && echo "xdebug.default_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+    && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+    && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+    && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+    && echo "xdebug.remote_port=9001" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini


### PR DESCRIPTION
Upgrading the PHP build Dockerfile to use PHP 8.0 and Xdebug 3:

- Service `php` now uses [`php:fpm-8.0`](https://github.com/docker-library/php/blob/57143cba9161c913cae8ba0a985bc30ba35130d2/8.0/buster/fpm/Dockerfile) as a base image.
    - Original PHP 7.3 configuration is retained in [**services/php/build/7.3.Dockerfile**](https://github.com/ikephelps/badockadock/compare/feature/php-eight?expand=1#diff-2e14530d43905c6ee1e3bd7162f0d4442ac49fbcb1a44f4413f3cebc7de76162).
- Upgrades to Xdebug 3.
    - Exposes (default) port `9003` for Xdebug connections.
- XML-RPC is now installed as a PECL extension - see https://php.watch/versions/8.0/xmlrpc.


To retain PHP 7 functionality, add the following to **docker-compose.override.yml**, under `services` -> `php` -> `build`:
```yml
services:
    php:
        build:
            dockerfile: 7.3.Dockerfile
```

To switch Xdebug "modes", modify the `XDEBUG_MODE` environment variable via **docker-compose.override.yml**:
```yml
services:
    php:
        environment:
            XDEBUG_MODE: "debug,develop"
```