### PR TITLE
Upgrade to NGINX 1.19

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,13 @@ services:
   nginx:
     depends_on:
       - php
+    env_file: ./services/nginx/nginx.env
     expose:
       - 80
       - 443
-    image: nginx:1.18
+    image: nginx:1.19
     volumes:
-      - ./services/nginx/conf.d/:/etc/nginx/conf.d/:ro
+      - ./services/nginx/templates/:/etc/nginx/templates/
       - nginx-ssl:/etc/ssl/site:ro
       - php-src:/var/www/php_src:ro
   php:

--- a/services/nginx/nginx.env
+++ b/services/nginx/nginx.env
@@ -1,0 +1,1 @@
+SERVER_NAME=_

--- a/services/nginx/templates/http-redirect.conf.template
+++ b/services/nginx/templates/http-redirect.conf.template
@@ -2,7 +2,7 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name _;
+    server_name ${SERVER_NAME};
 
     return 301 https://$host$request_uri;
 }

--- a/services/nginx/templates/site.conf.template
+++ b/services/nginx/templates/site.conf.template
@@ -2,7 +2,7 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name _;
+    server_name ${SERVER_NAME};
 
     ssl_certificate     /etc/ssl/site/certs/site.cert.pem;
     ssl_certificate_key /etc/ssl/site/private/site.key.pem;


### PR DESCRIPTION
Upgrading the NGINX service to use NGINX 1.19:

- Converts the config files in **services/nginx/conf.d** to **.template** files, now located under **services/nginx/templates**.
- Adds an [**.env** file](https://github.com/ikephelps/badockadock/compare/feature/nginx-one-nineteen?expand=1#diff-60842c1c68c3fdc0407cd8f29d75af3abb9236b2b185e69e2c67369139a24b08) with a default `server_name`.

Template files are converted to **.conf** files at startup, replacing any placeholders (e.g. - `${SERVER_NAME}`) with the associated environment variables!

### Example
To change `SERVER_NAME`, add the following to **docker-compose.override.yml**, under `services` -> `nginx` -> `environment`:
```yml
services:
    nginx:
        environment:
            SERVER_NAME: "test.badockadock.dev"
```

See also: https://docs.docker.com/compose/environment-variables/