### PR TITLE
NGINX - SSL Certificate Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 .env
 docker-compose.override.yml
 /services-ext/*
+
+## Nginx ##
+/services/nginx/certs/*

--- a/services/nginx/ca.openssl.cnf
+++ b/services/nginx/ca.openssl.cnf
@@ -1,0 +1,12 @@
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions    = v3_req
+prompt             = no
+
+[req_distinguished_name]
+commonName = Badockadock CA
+
+[v3_req]
+basicConstraints = critical,CA:TRUE,pathlen:1
+keyUsage         = critical,keyCertSign,cRLSign
+extendedKeyUsage = critical,serverAuth

--- a/services/nginx/ca_gen.sh
+++ b/services/nginx/ca_gen.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+## Generate CA certificate/key pair
+openssl req \
+  -x509 \
+  -new \
+  -newkey rsa:4096 \
+  -nodes \
+  -config ca.openssl.cnf \
+  -days 3650 \
+  -keyout $HOME/.ssl/ca.key.pem \
+  -out $HOME/.ssl/ca.cert.pem
+
+## Add CA certificate to keychain
+security add-trusted-cert \
+  -k $HOME/Library/Keychains/login.keychain-db \
+  -r trustRoot \
+  $HOME/.ssl/ca.cert.pem

--- a/services/nginx/cert_gen.sh
+++ b/services/nginx/cert_gen.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ ! -d certs ]; then
+  mkdir certs
+fi
+
+## Generate server key
+openssl genrsa -out certs/key.pem 2048
+
+## Generate Certificate Signing Request (CSR)
+#  -sha256
+openssl req \
+  -new \
+  -key certs/key.pem \
+  -config openssl.cnf \
+  -out server.csr
+
+## Sign CSR using CA
+openssl x509 \
+  -req \
+  -sha256 \
+  -CA $HOME/.ssl/ca.cert.pem \
+  -CAkey $HOME/.ssl/ca.key.pem \
+  -CAcreateserial \
+  -in server.csr \
+  -extensions req_ext \
+  -extfile openssl.cnf \
+  -days 360 \
+  -out certs/cert.pem
+
+## Remove CSR
+rm server.csr

--- a/services/nginx/conf.d/site.conf
+++ b/services/nginx/conf.d/site.conf
@@ -4,8 +4,8 @@ server {
 
     server_name _;
 
-    ssl_certificate     /etc/ssl/site/certs/site.cert.pem;
-    ssl_certificate_key /etc/ssl/site/private/site.key.pem;
+    ssl_certificate     /etc/ssl/site/cert.pem;
+    ssl_certificate_key /etc/ssl/site/key.pem;
     ssl_protocols       TLSv1.2;
 
     root  /var/www/php_src/public;


### PR DESCRIPTION
Adding some utility scripts for SSL certificate generation for NGXIN:

**ca_gen.ssh** - makes root CA certificates for signing.
**cert_gen.ssh** - makes site certificates using the CA from above.